### PR TITLE
chore(release): version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 16/04/2026
+
+### Ajouté
+
+- Champ booléen `is_admin` sur la table `users` (migration + cast `bool` dans le modèle `User`)
+- Factory state `admin()` sur `UserFactory` pour créer des utilisateurs administrateurs
+- `AdminSeeder` : crée le compte admin par défaut (`admin@cinemap.fr` / `Admin123!`) via le state factory
+- `AdminMiddleware` (`app/Http/Middleware/AdminMiddleware.php`) : renvoie un 403 si l'utilisateur n'est pas authentifié ou n'a pas `is_admin = true`
+- Alias `admin` enregistré dans `bootstrap/app.php` pour utiliser le middleware dans les routes
+
+### Changement
+
+- Route `/dashboard` : middleware `['auth', 'admin']` — accès réservé aux administrateurs
+- Routes CRUD Films et route `localisations.index` déplacées dans un groupe `['auth', 'admin']`
+- `LocalisationController` (`edit`, `update`, `destroy`) : la vérification du propriétaire autorise désormais aussi les admins (`|| auth()->user()->is_admin`)
+- Navigation (`layouts/navigation.blade.php`) : lien « Dashboard » conditionnel — affiché uniquement si `auth()->user()->is_admin`, sur desktop et mobile
+- Vue `films.show` : boutons « Modifier » / « Supprimer » d'une localisation visibles pour le propriétaire **ou** un admin
+
+---
+
 ## [0.2.0] - 16/04/2026
 
 ### Ajouté

--- a/cinemap-app/app/Http/Controllers/LocalisationController.php
+++ b/cinemap-app/app/Http/Controllers/LocalisationController.php
@@ -49,7 +49,10 @@ class LocalisationController extends Controller
 
     public function edit(Localisation $localisation): View
     {
-        abort_if(auth()->id() !== $localisation->user_id, 403);
+        abort_if(
+            auth()->id() !== $localisation->user_id && ! auth()->user()->is_admin,
+            403
+        );
 
         return view('localisations.edit', [
             'localisation' => $localisation,
@@ -59,7 +62,10 @@ class LocalisationController extends Controller
 
     public function update(Request $request, Localisation $localisation): RedirectResponse
     {
-        abort_if(auth()->id() !== $localisation->user_id, 403);
+        abort_if(
+            auth()->id() !== $localisation->user_id && ! auth()->user()->is_admin,
+            403
+        );
 
         $localisation->update($this->validatedData($request, $localisation));
 
@@ -70,7 +76,10 @@ class LocalisationController extends Controller
 
     public function destroy(Localisation $localisation): RedirectResponse
     {
-        abort_if(auth()->id() !== $localisation->user_id, 403);
+        abort_if(
+            auth()->id() !== $localisation->user_id && ! auth()->user()->is_admin,
+            403
+        );
 
         $localisation->delete();
 

--- a/cinemap-app/app/Http/Middleware/AdminMiddleware.php
+++ b/cinemap-app/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! auth()->check() || ! auth()->user()->is_admin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/cinemap-app/app/Models/User.php
+++ b/cinemap-app/app/Models/User.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-#[Fillable(['name', 'email', 'password'])]
+#[Fillable(['name', 'email', 'password', 'is_admin'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/cinemap-app/bootstrap/app.php
+++ b/cinemap-app/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AdminMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'admin' => AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/cinemap-app/database/factories/UserFactory.php
+++ b/cinemap-app/database/factories/UserFactory.php
@@ -42,4 +42,11 @@ class UserFactory extends Factory
             'email_verified_at' => null,
         ]);
     }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_admin' => true,
+        ]);
+    }
 }

--- a/cinemap-app/database/migrations/2026_04_16_110333_add_is_admin_to_users_table.php
+++ b/cinemap-app/database/migrations/2026_04_16_110333_add_is_admin_to_users_table.php
@@ -11,9 +11,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('locations', function (Blueprint $table) {
-            $table->id();
-            $table->timestamps();
+        Schema::table('users', function (Blueprint $table) {
+            //
+            $table->boolean('is_admin')->default(false)->after('password');
         });
     }
 
@@ -22,6 +22,9 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('locations');
+        Schema::table('users', function (Blueprint $table) {
+            //
+            $table->dropColumn('is_admin');
+        });
     }
 };

--- a/cinemap-app/database/seeders/AdminSeeder.php
+++ b/cinemap-app/database/seeders/AdminSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class AdminSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::factory()->admin()->create([
+            'name'     => 'Admin',
+            'email'    => 'admin@cinemap.fr',
+            'password' => Hash::make('Admin123!'),
+        ]);
+    }
+}

--- a/cinemap-app/database/seeders/DatabaseSeeder.php
+++ b/cinemap-app/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Database\Seeders\AdminSeeder;
 use Database\Seeders\FilmSeeder;
 use Database\Seeders\LocalisationSeeder;
 
@@ -20,17 +21,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
+        $this->call([AdminSeeder::class]);
+
         User::factory()->create([
-            'name' => 'Test User',
+            'name'  => 'Test User',
             'email' => 'test@example.com',
         ]);
 
-        $this->call([
-            FilmSeeder::class,
-        ]);
-
-        $this->call([
-            LocalisationSeeder::class,
-        ]);
+        $this->call([FilmSeeder::class]);
+        $this->call([LocalisationSeeder::class]);
     }
 }

--- a/cinemap-app/resources/views/films/show.blade.php
+++ b/cinemap-app/resources/views/films/show.blade.php
@@ -97,7 +97,7 @@
                         </div>
 
                         @auth
-                            @if (auth()->id() === $localisation->user_id)
+                            @if (auth()->id() === $localisation->user_id || auth()->user()->is_admin)
                                 <div class="flex gap-2 flex-shrink-0">
                                     <a href="{{ route('localisations.edit', $localisation) }}"
                                        class="text-xs text-indigo-600 hover:text-indigo-900 dark:text-indigo-400">

--- a/cinemap-app/resources/views/layouts/navigation.blade.php
+++ b/cinemap-app/resources/views/layouts/navigation.blade.php
@@ -5,7 +5,7 @@
             <div class="flex">
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}">
+                    <a href="{{ route('home') }}">
                         <x-application-logo class="block h-9 w-auto fill-current text-gray-800 dark:text-gray-200" />
                     </a>
                 </div>
@@ -16,9 +16,11 @@
                         Accueil
                     </x-nav-link>
                     @auth
+                    @if (auth()->user()->is_admin)
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         Dashboard
                     </x-nav-link>
+                    @endif
                     @endauth
                 </div>
             </div>
@@ -87,9 +89,11 @@
                 Accueil
             </x-responsive-nav-link>
             @auth
+            @if (auth()->user()->is_admin)
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 Dashboard
             </x-responsive-nav-link>
+            @endif
             @endauth
         </div>
 

--- a/cinemap-app/routes/web.php
+++ b/cinemap-app/routes/web.php
@@ -14,7 +14,7 @@ Route::get('/home', [HomeController::class, 'index'])->name('home');
 
 Route::get('/dashboard', function () {
     return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+})->middleware(['auth', 'admin'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/cinemap-app/routes/web.php
+++ b/cinemap-app/routes/web.php
@@ -21,17 +21,6 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
-    // Dashboard — gestion des films (auth, plus tard admin)
-    Route::get('/films', [FilmController::class, 'index'])->name('films.index');
-    Route::get('/films/create', [FilmController::class, 'create'])->name('films.create');
-    Route::post('/films', [FilmController::class, 'store'])->name('films.store');
-    Route::get('/films/{film}/edit', [FilmController::class, 'edit'])->name('films.edit');
-    Route::put('/films/{film}', [FilmController::class, 'update'])->name('films.update');
-    Route::delete('/films/{film}', [FilmController::class, 'destroy'])->name('films.destroy');
-
-    // Dashboard — liste de toutes les localisations (auth, plus tard admin)
-    Route::get('/localisations', [LocalisationController::class, 'index'])->name('localisations.index');
-
     // Localisations — actions utilisateur (ses propres localisations)
     Route::get('/localisations/create', [LocalisationController::class, 'create'])->name('localisations.create');
     Route::post('/localisations', [LocalisationController::class, 'store'])->name('localisations.store');
@@ -39,6 +28,19 @@ Route::middleware('auth')->group(function () {
     Route::put('/localisations/{localisation}', [LocalisationController::class, 'update'])->name('localisations.update');
     Route::delete('/localisations/{localisation}', [LocalisationController::class, 'destroy'])->name('localisations.destroy');
 });
+
+// Dashboard — réservé aux admins
+Route::middleware(['auth', 'admin'])->group(function () {
+    Route::get('/films', [FilmController::class, 'index'])->name('films.index');
+    Route::get('/films/create', [FilmController::class, 'create'])->name('films.create');
+    Route::post('/films', [FilmController::class, 'store'])->name('films.store');
+    Route::get('/films/{film}/edit', [FilmController::class, 'edit'])->name('films.edit');
+    Route::put('/films/{film}', [FilmController::class, 'update'])->name('films.update');
+    Route::delete('/films/{film}', [FilmController::class, 'destroy'])->name('films.destroy');
+
+    Route::get('/localisations', [LocalisationController::class, 'index'])->name('localisations.index');
+});
+
 
 // Routes publiques paramétrées — définies APRÈS le groupe auth
 // pour que /films/create et /localisations/create soient capturés en premier

--- a/docs/res-tp.md
+++ b/docs/res-tp.md
@@ -407,6 +407,7 @@ Dans `handle()`, vérifier `auth()->user()->is_admin`.
 
 | Action | Utilisateur classique | Admin |
 |---|---|---|
+| Accès dashboard | Non | Oui |
 | Créer un film | Non | Oui |
 | Modifier / supprimer un film | Non | Oui |
 | Créer un emplacement | Oui | Oui |
@@ -429,7 +430,7 @@ Dans `handle()`, vérifier `auth()->user()->is_admin`.
 ### Modèle de données
 
 ```bash
-php artisan make:migration create_location_votes_table
+php artisan make:migration create_localisation_votes_table
 ```
 
 ```php
@@ -446,7 +447,7 @@ $table->unique(['user_id', 'location_id']); // 1 vote par utilisateur
 
 ```php
 // routes/web.php
-Route::post('/locations/{location}/upvote', [LocationController::class, 'upvote'])->middleware('auth');
+Route::post('/locations/{location}/upvote', [LocalisationController::class, 'upvote'])->middleware('auth');
 ```
 
 3. Dans l'action `upvote`, enregistrer le vote et dispatcher un job :

--- a/docs/res-tp.md
+++ b/docs/res-tp.md
@@ -383,27 +383,104 @@ Toutes les vues étendent `<x-app-layout>` et utilisent les composants Breeze (`
 
 ### Ce qu'il faut faire
 
-1. Ajouter le champ `is_admin` à la table `users` :
+#### Ajouter le champ `is_admin` à la table `users` :
 
 ```bash
 php artisan make:migration add_is_admin_to_users_table
 ```
 
 ```php
-$table->boolean('is_admin')->default(false);
+public function up(): void
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->boolean('is_admin')->default(false)->after('password');
+    });
+}
+
+public function down(): void
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->dropColumn('is_admin');
+    });
+}
 ```
 
-2. Créer le middleware :
+```bash
+php artisan migrate
+```
+
+#### Créer le middleware :
+
+1. Générer le middleware
 
 ```bash
 php artisan make:middleware AdminMiddleware
 ```
+Cela crée `app/Http/Middleware/AdminMiddleware.php`.
 
-Dans `handle()`, vérifier `auth()->user()->is_admin`.
+2. Écrire la logique dans handle()
 
-3. Enregistrer le middleware dans `bootstrap/app.php` (Laravel 11) ou `Kernel.php` (Laravel 10).
+Le fichier généré contient une méthode handle(). Il faut y vérifier que l'utilisateur est connecté et admin, sinon rediriger ou retourner une 403 :
 
-4. Appliquer les règles :
+```php
+public function handle(Request $request, Closure $next): Response
+{
+    if (! auth()->check() || ! auth()->user()->is_admin) {
+        abort(403);
+    }
+
+    return $next($request);
+}
+```
+
+3. Enregistrer le middleware dans bootstrap/app.php 
+
+Les middlewares s'enregistrent dans `bootstrap/app.php` via `withMiddleware()` :
+
+```php
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->alias([
+        'admin' => \App\Http\Middleware\AdminMiddleware::class,
+    ]);
+})
+```
+
+alias permet de lui donner un nom court ('admin') pour l'utiliser dans les routes.
+
+4. Utiliser le middleware sur les routes
+
+Une fois enregistré, protéger les routes du dashboard :
+
+```php
+// Dashboard — réservé aux admins
+Route::middleware(['auth', 'admin'])->group(function () {
+    Route::get('/films', [FilmController::class, 'index'])->name('films.index');
+    Route::get('/films/create', [FilmController::class, 'create'])->name('films.create');
+    Route::post('/films', [FilmController::class, 'store'])->name('films.store');
+    Route::get('/films/{film}/edit', [FilmController::class, 'edit'])->name('films.edit');
+    Route::put('/films/{film}', [FilmController::class, 'update'])->name('films.update');
+    Route::delete('/films/{film}', [FilmController::class, 'destroy'])->name('films.destroy');
+
+    Route::get('/localisations', [LocalisationController::class, 'index'])->name('localisations.index');
+});
+```
+
+auth vérifie que l'utilisateur est connecté, admin vérifie qu'il est admin. Les deux sont nécessaires — admin seul planterait si personne n'est connecté (auth()->user() serait null).
+
+#### Seed Admin
+
+Vérifier que ça fonctionne
+Pour tester sans implémenter de page d'admin, passer temporairement is_admin = true à l'utilisateur du seeder et lui donner un mot de passe généré manuellement:
+
+```php
+User::factory()->create([
+    'name'     => 'Admin',
+    'email'    => 'admin@example.com',
+    'is_admin' => true,
+]);
+```
+
+#### Appliquer les règles :
 
 | Action | Utilisateur classique | Admin |
 |---|---|---|

--- a/docs/res-tp.md
+++ b/docs/res-tp.md
@@ -492,12 +492,54 @@ User::factory()->create([
 | Modifier / supprimer **ses** emplacements | Oui | Oui |
 | Modifier / supprimer **tous** les emplacements | Non | Oui |
 
-### Checklist
+1. routes/web.php 
 
-- [ ] Champ `is_admin` ajouté
-- [ ] Middleware `admin` créé et enregistré
-- [ ] Routes admin protégées
-- [ ] Un utilisateur classique ne peut modifier que ses propres emplacements
+Déjà fait
+
+2. LocalisationController.php — modifier edit, update, destroy
+
+Actuellement la règle est : propriétaire uniquement. Il faut la changer en : propriétaire OU admin.
+
+```php
+// Actuellement :
+abort_if(auth()->id() !== $localisation->user_id, 403);
+
+// À remplacer par :
+abort_if(
+    auth()->id() !== $localisation->user_id && ! auth()->user()->is_admin,
+    403
+);
+```
+
+À appliquer dans les 3 méthodes : edit(), update(), destroy().
+
+3. Vues — masquer les boutons dashboard aux non-admins
+
+`films/show.blade.php` et `localisations/index.blade.php`
+Les boutons "Modifier"/"Supprimer" dans la vue `films/show` sur les localisations doivent aussi tenir compte de l'admin :
+
+```php
+// Actuellement :
+@if (auth()->id() === $localisation->user_id)
+
+// À remplacer par :
+@if (auth()->id() === $localisation->user_id || auth()->user()->is_admin)
+navigation.blade.php
+Le lien "Dashboard" dans la nav ne devrait être visible que pour les admins :
+
+
+// Actuellement :
+@auth
+    <x-nav-link :href="route('dashboard')">Dashboard</x-nav-link>
+@endauth
+
+// À remplacer par :
+@auth
+    @if (auth()->user()->is_admin)
+        <x-nav-link :href="route('dashboard')">Dashboard</x-nav-link>
+    @endif
+@endauth
+```
 
 ---
 

--- a/docs/res-tp.md
+++ b/docs/res-tp.md
@@ -476,6 +476,7 @@ Pour tester sans implémenter de page d'admin, passer temporairement is_admin = 
 User::factory()->create([
     'name'     => 'Admin',
     'email'    => 'admin@example.com',
+    'password' => 'Admin123!',
     'is_admin' => true,
 ]);
 ```


### PR DESCRIPTION
### Ajouté

- Champ booléen `is_admin` sur la table `users` (migration + cast `bool` dans le modèle `User`)
- Factory state `admin()` sur `UserFactory` pour créer des utilisateurs administrateurs
- `AdminSeeder` : crée le compte admin par défaut (`admin@cinemap.fr` / `Admin123!`) via le state factory
- `AdminMiddleware` (`app/Http/Middleware/AdminMiddleware.php`) : renvoie un 403 si l'utilisateur n'est pas authentifié ou n'a pas `is_admin = true`
- Alias `admin` enregistré dans `bootstrap/app.php` pour utiliser le middleware dans les routes

### Changement

- Route `/dashboard` : middleware `['auth', 'admin']` — accès réservé aux administrateurs
- Routes CRUD Films et route `localisations.index` déplacées dans un groupe `['auth', 'admin']`
- `LocalisationController` (`edit`, `update`, `destroy`) : la vérification du propriétaire autorise désormais aussi les admins (`|| auth()->user()->is_admin`)
- Navigation (`layouts/navigation.blade.php`) : lien « Dashboard » conditionnel — affiché uniquement si `auth()->user()->is_admin`, sur desktop et mobile
- Vue `films.show` : boutons « Modifier » / « Supprimer » d'une localisation visibles pour le propriétaire **ou** un admin