### PR TITLE
chore(release): version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Supprimé
 
 -
+---
+
+## [0.8.0] - 17/04/2026
+
+### Ajouté
+
+- Package `laravel/cashier` installé (abonnements Stripe récurrents)
+- Trait `Billable` ajouté au modèle `User`
+- Migrations Cashier publiées (`vendor:publish --tag="cashier-migrations"`) et appliquées : colonnes Stripe sur `users` + table `subscriptions`
+- Variables `.env` : `STRIPE_KEY`, `STRIPE_SECRET`, `STRIPE_PRICE_ID`
+- Produit et prix récurrent créé dans le dashboard Stripe (`5 €/mois`)
+- `SubscriptionController` avec `index` (page abonnement) et `store` (souscription via `newSubscription`)
+- Vue `subscription/index.blade.php` : card tarif + formulaire Stripe Elements (SetupIntent)
+- Si l'utilisateur est déjà abonné : formulaire grisé (`opacity-50 pointer-events-none`), bouton désactivé, JS Stripe non chargé
+- Routes `GET /subscription` et `POST /subscription` dans le groupe `middleware('auth')`
+- Package `php-open-source-saver/jwt-auth` installé
+- Config JWT publiée (`vendor:publish --provider="PHPOpenSourceSaver\JWTAuth\..."`) et secret généré (`php artisan jwt:secret` → `JWT_SECRET` dans `.env`)
+- Guard `api` avec driver `jwt` dans `config/auth.php`
+- Interface `JWTSubject` implémentée sur `User` (`getJWTIdentifier`, `getJWTCustomClaims`)
+- `ApiAuthController@login` : vérifie les credentials ET l'abonnement avant de délivrer le token JWT (401 si mauvais credentials, 403 si non abonné)
+- `FilmApiController@locations` : retourne le film et ses localisations en JSON (champs sélectifs)
+- `routes/api.php` déclaré avec `Route::post('/auth/login')` public et `GET /films/{film}/locations` protégé par `middleware('auth:api')`
+- `routes/api.php` enregistré dans `bootstrap/app.php` (obligatoire en Laravel 11 — non chargé automatiquement)
+
+### Corrigé
+
+- `ext-bcmath` manquant : `sudo apt install php8.3-bcmath` requis par Cashier v16
+- Migrations Cashier en double (double `vendor:publish`) : suppression du second jeu de fichiers + `migrate:fresh --seed`
+- `STRIPE_PRICE_ID` non renseigné dans `.env` → `newSubscription()` recevait `null` — corrigé en ajoutant la variable
+- `GET /api/films/1/locations` retournait 404 en Laravel 11 : `routes/api.php` n'est pas auto-chargé — résolu en ajoutant `api: __DIR__.'/../routes/api.php'` dans `bootstrap/app.php`
+- `Target class [subscribed] does not exist` (HTTP 500) : middleware `subscribed` inexistant retiré de `routes/api.php` — la vérification d'abonnement est dans `ApiAuthController@login`
+- Redirection après inscription vers `/dashboard` (inexistant) → corrigé en `route('home')` dans `RegisteredUserController@store`
 
 ---
 

--- a/cinemap-app/app/Http/Controllers/ApiAuthController.php
+++ b/cinemap-app/app/Http/Controllers/ApiAuthController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ApiAuthController extends Controller
+{
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        if (! $token = Auth::guard('api')->attempt($credentials)) {
+            return response()->json(['error' => 'Identifiants invalides'], 401);
+        }
+
+        $user = Auth::guard('api')->user();
+
+        if (! $user->subscribed('default')) {
+            Auth::guard('api')->logout();
+
+            return response()->json(['error' => 'Abonnement requis'], 403);
+        }
+
+        return response()->json(['token' => $token]);
+    }
+}

--- a/cinemap-app/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/cinemap-app/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -46,6 +46,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect(route('dashboard', absolute: false));
+        return redirect(route('home', absolute: false));
     }
 }

--- a/cinemap-app/app/Http/Controllers/FilmApiController.php
+++ b/cinemap-app/app/Http/Controllers/FilmApiController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Film;
+
+class FilmApiController extends Controller
+{
+    public function locations(Film $film)
+    {
+        return response()->json([
+            'film' => $film->only(['id', 'name', 'producer', 'release_year', 'synopsis']),
+            'localisations' => $film->localisations()->get([
+                'id', 'name', 'city', 'country', 'description', 'upvotes_count',
+            ]),
+        ]);
+    }
+}

--- a/cinemap-app/app/Http/Controllers/SubscriptionController.php
+++ b/cinemap-app/app/Http/Controllers/SubscriptionController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class SubscriptionController extends Controller
+{
+    //
+
+    public function index()
+    {
+        return view('subscription.index', [
+            'intent' => auth()->user()->createSetupIntent(),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate(['payment_method' => 'required']);
+
+        $user = auth()->user();
+
+        $user->createOrGetStripeCustomer();
+
+        $user->addPaymentMethod($request->payment_method);
+
+        $user->newSubscription('default', env('STRIPE_PRICE_ID'))
+            ->create($request->payment_method);
+
+        return redirect('/home')->with('success', 'Abonnement activé !');
+    }
+}

--- a/cinemap-app/app/Http/Controllers/SubscriptionController.php
+++ b/cinemap-app/app/Http/Controllers/SubscriptionController.php
@@ -10,21 +10,27 @@ class SubscriptionController extends Controller
 
     public function index()
     {
+        $user = auth()->user();
+
         return view('subscription.index', [
-            'intent' => auth()->user()->createSetupIntent(),
+            'intent' => $user->subscribed('default') ? null : $user->createSetupIntent(),
+            'subscribed' => $user->subscribed('default'),
         ]);
     }
 
     public function store(Request $request)
     {
-        $request->validate(['payment_method' => 'required']);
-
         $user = auth()->user();
 
+        if ($user->subscribed('default')) {
+            return redirect()->route('subscription.index')
+                ->with('error', 'Vous êtes déjà abonné.');
+        }
+
+        $request->validate(['payment_method' => 'required']);
+
         $user->createOrGetStripeCustomer();
-
         $user->addPaymentMethod($request->payment_method);
-
         $user->newSubscription('default', env('STRIPE_PRICE_ID'))
             ->create($request->payment_method);
 

--- a/cinemap-app/app/Models/User.php
+++ b/cinemap-app/app/Models/User.php
@@ -9,13 +9,14 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Cashier\Billable;
 
 #[Fillable(['name', 'email', 'password', 'is_admin', 'oauth_id'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Billable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/cinemap-app/app/Models/User.php
+++ b/cinemap-app/app/Models/User.php
@@ -10,13 +10,24 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Cashier\Billable;
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
 
 #[Fillable(['name', 'email', 'password', 'is_admin', 'oauth_id'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements JWTSubject
 {
     /** @use HasFactory<UserFactory> */
     use Billable, HasFactory, Notifiable;
+
+    public function getJWTIdentifier(): mixed
+    {
+        return $this->getKey();
+    }
+
+    public function getJWTCustomClaims(): array
+    {
+        return [];
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/cinemap-app/bootstrap/app.php
+++ b/cinemap-app/bootstrap/app.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/cinemap-app/composer.json
+++ b/cinemap-app/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "laravel/cashier": "^16.5",
         "laravel/framework": "^13.0",
         "laravel/socialite": "^5.26",
         "laravel/tinker": "^3.0",

--- a/cinemap-app/composer.json
+++ b/cinemap-app/composer.json
@@ -11,6 +11,7 @@
         "laravel/framework": "^13.0",
         "laravel/socialite": "^5.26",
         "laravel/tinker": "^3.0",
+        "php-open-source-saver/jwt-auth": "^2.9",
         "socialiteproviders/discord": "^4.2"
     },
     "require-dev": {

--- a/cinemap-app/composer.lock
+++ b/cinemap-app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7604044030f130c632724069398b6948",
+    "content-hash": "54ca38da440f47e0c1d9adfb30ecb5fe",
     "packages": [
         {
             "name": "brick/math",
@@ -1691,6 +1691,79 @@
             "time": "2026-03-17T14:54:13+00:00"
         },
         {
+            "name": "lcobucci/jwt",
+            "version": "5.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-17T11:30:53+00:00"
+        },
+        {
             "name": "league/commonmark",
             "version": "2.8.2",
             "source": {
@@ -2519,6 +2592,73 @@
             "time": "2026-01-02T08:56:05+00:00"
         },
         {
+            "name": "namshi/jose",
+            "version": "7.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/namshi/jose.git",
+                "reference": "89a24d7eb3040e285dd5925fcad992378b82bcff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/namshi/jose/zipball/89a24d7eb3040e285dd5925fcad992378b82bcff",
+                "reference": "89a24d7eb3040e285dd5925fcad992378b82bcff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-date": "*",
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-spl": "*",
+                "php": ">=5.5",
+                "symfony/polyfill-php56": "^1.0"
+            },
+            "require-dev": {
+                "phpseclib/phpseclib": "^2.0",
+                "phpunit/phpunit": "^4.5|^5.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "suggest": {
+                "ext-openssl": "Allows to use OpenSSL as crypto engine.",
+                "phpseclib/phpseclib": "Allows to use Phpseclib as crypto engine, use version ^2.0."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Namshi\\JOSE\\": "src/Namshi/JOSE/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Nadalin",
+                    "email": "alessandro.nadalin@gmail.com"
+                },
+                {
+                    "name": "Alessandro Cinelli (cirpo)",
+                    "email": "alessandro.cinelli@gmail.com"
+                }
+            ],
+            "description": "JSON Object Signing and Encryption library for PHP.",
+            "keywords": [
+                "JSON Web Signature",
+                "JSON Web Token",
+                "JWS",
+                "json",
+                "jwt",
+                "token"
+            ],
+            "support": {
+                "issues": "https://github.com/namshi/jose/issues",
+                "source": "https://github.com/namshi/jose/tree/master"
+            },
+            "time": "2016-12-05T07:27:31+00:00"
+        },
+        {
             "name": "nesbot/carbon",
             "version": "3.11.4",
             "source": {
@@ -3044,6 +3184,99 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "php-open-source-saver/jwt-auth",
+            "version": "v2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-Open-Source-Saver/jwt-auth.git",
+                "reference": "648306caac5218e2daebfd2fac0130318ed4bdfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-Open-Source-Saver/jwt-auth/zipball/648306caac5218e2daebfd2fac0130318ed4bdfa",
+                "reference": "648306caac5218e2daebfd2fac0130318ed4bdfa",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/auth": "^12|^13",
+                "illuminate/contracts": "^12|^13",
+                "illuminate/http": "^12|^13",
+                "illuminate/support": "^12|^13",
+                "lcobucci/jwt": "^5.4",
+                "namshi/jose": "^7.0",
+                "nesbot/carbon": "^2.0|^3.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "illuminate/console": "^12|^13",
+                "illuminate/routing": "^12|^13",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^10|^11",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10.5|^11"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "JWTAuth": "PHPOpenSourceSaver\\JWTAuth\\Facades\\JWTAuth",
+                        "JWTFactory": "PHPOpenSourceSaver\\JWTAuth\\Facades\\JWTFactory"
+                    },
+                    "providers": [
+                        "PHPOpenSourceSaver\\JWTAuth\\Providers\\LaravelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPOpenSourceSaver\\JWTAuth\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sean Tymon",
+                    "email": "tymon148@gmail.com",
+                    "homepage": "https://tymon.xyz",
+                    "role": "Forked package creator | Developer"
+                },
+                {
+                    "name": "Eric Schricker",
+                    "email": "eric.schricker@adiutabyte.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Fabio William Conceição",
+                    "email": "messhias@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Max Snow",
+                    "email": "contact@maxsnow.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "JSON Web Token Authentication for Laravel and Lumen",
+            "homepage": "https://github.com/PHP-Open-Source-Saver/jwt-auth",
+            "keywords": [
+                "Authentication",
+                "JSON Web Token",
+                "auth",
+                "jwt",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-Open-Source-Saver/jwt-auth/issues",
+                "source": "https://github.com/PHP-Open-Source-Saver/jwt-auth"
+            },
+            "time": "2026-03-06T00:13:17+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -5608,6 +5841,74 @@
                 }
             ],
             "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php56",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php56.git",
+                "reference": "54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675",
+                "reference": "54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "metapackage",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                },
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php56/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php80",

--- a/cinemap-app/composer.lock
+++ b/cinemap-app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cec16c1ae01529d7e468644cad8c897",
+    "content-hash": "7604044030f130c632724069398b6948",
     "packages": [
         {
             "name": "brick/math",
@@ -1116,6 +1116,95 @@
                 }
             ],
             "time": "2025-08-22T14:27:06+00:00"
+        },
+        {
+            "name": "laravel/cashier",
+            "version": "v16.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/cashier-stripe.git",
+                "reference": "49a581bccb5e56a45e1c8ee94587ce3420203a7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/cashier-stripe/zipball/49a581bccb5e56a45e1c8ee94587ce3420203a7a",
+                "reference": "49a581bccb5e56a45e1c8ee94587ce3420203a7a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/log": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/notifications": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/pagination": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/view": "^10.0|^11.0|^12.0|^13.0",
+                "moneyphp/money": "^4.0",
+                "nesbot/carbon": "^2.0|^3.0",
+                "php": "^8.1",
+                "stripe/stripe-php": "^17.3.0",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.0|^7.0|^8.0",
+                "symfony/polyfill-intl-icu": "^1.22.1",
+                "symfony/polyfill-php84": "^1.32"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^2.0|^3.0",
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10",
+                "spatie/laravel-ray": "^1.40"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Required when generating and downloading invoice PDF's using Dompdf (^2.0|^3.0).",
+                "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values.",
+                "spatie/laravel-pdf": "Required when generating and downloading invoice PDF's using Cashier's LaravelPdfInvoiceRenderer."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Cashier\\CashierServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Cashier\\": "src/",
+                    "Laravel\\Cashier\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Dries Vints",
+                    "email": "dries@laravel.com"
+                }
+            ],
+            "description": "Laravel Cashier provides an expressive, fluent interface to Stripe's subscription billing services.",
+            "keywords": [
+                "billing",
+                "laravel",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/cashier/issues",
+                "source": "https://github.com/laravel/cashier"
+            },
+            "time": "2026-04-01T15:57:36+00:00"
         },
         {
             "name": "laravel/framework",
@@ -2235,6 +2324,96 @@
                 }
             ],
             "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "moneyphp/money",
+            "version": "v4.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/moneyphp/money.git",
+                "reference": "b358727ea5a5cd2d7475e59c31dfc352440ae7ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/b358727ea5a5cd2d7475e59c31dfc352440ae7ec",
+                "reference": "b358727ea5a5cd2d7475e59c31dfc352440ae7ec",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "cache/taggable-cache": "^1.1.0",
+                "doctrine/coding-standard": "^12.0",
+                "doctrine/instantiator": "^1.5.0 || ^2.0",
+                "ext-gmp": "*",
+                "ext-intl": "*",
+                "florianv/exchanger": "^2.8.1",
+                "florianv/swap": "^4.3.0",
+                "moneyphp/crypto-currencies": "^1.1.0",
+                "moneyphp/iso-currencies": "^3.4",
+                "php-http/message": "^1.16.0",
+                "php-http/mock-client": "^1.6.0",
+                "phpbench/phpbench": "^1.2.5",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1.9",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.9",
+                "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
+                "ticketswap/phpstan-error-formatter": "^1.1"
+            },
+            "suggest": {
+                "ext-gmp": "Calculate without integer limits",
+                "ext-intl": "Format Money objects with intl",
+                "florianv/exchanger": "Exchange rates library for PHP",
+                "florianv/swap": "Exchange rates library for PHP",
+                "psr/cache-implementation": "Used for Currency caching"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Money\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Verraes",
+                    "email": "mathias@verraes.net",
+                    "homepage": "http://verraes.net"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Frederik Bosch",
+                    "email": "f.bosch@genkgo.nl"
+                }
+            ],
+            "description": "PHP implementation of Fowler's Money pattern",
+            "homepage": "http://moneyphp.org",
+            "keywords": [
+                "Value Object",
+                "money",
+                "vo"
+            ],
+            "support": {
+                "issues": "https://github.com/moneyphp/money/issues",
+                "source": "https://github.com/moneyphp/money/tree/v4.8.0"
+            },
+            "time": "2025-10-23T07:55:09+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3865,6 +4044,65 @@
             "time": "2026-03-18T22:13:24+00:00"
         },
         {
+            "name": "stripe/stripe-php",
+            "version": "v17.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "a6219df5df1324a0d3f1da25fb5e4b8a3307ea16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/a6219df5df1324a0d3f1da25fb5e4b8a3307ea16",
+                "reference": "a6219df5df1324a0d3f1da25fb5e4b8a3307ea16",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.72.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v17.6.0"
+            },
+            "time": "2025-08-27T19:32:42+00:00"
+        },
+        {
             "name": "symfony/clock",
             "version": "v7.4.8",
             "source": {
@@ -5025,6 +5263,94 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "3510b63d07376b04e57e27e82607d468bb134f78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/3510b63d07376b04e57e27e82607d468bb134f78",
+                "reference": "3510b63d07376b04e57e27e82607d468bb134f78",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance and support of other locales than \"en\""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Icu\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's ICU-related data and classes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "icu",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:50:15+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",

--- a/cinemap-app/config/auth.php
+++ b/cinemap-app/config/auth.php
@@ -42,6 +42,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'api' => [
+            'driver' => 'jwt',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/cinemap-app/config/jwt.php
+++ b/cinemap-app/config/jwt.php
@@ -1,0 +1,324 @@
+<?php
+
+use PHPOpenSourceSaver\JWTAuth\Providers\Auth\Illuminate;
+use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Lcobucci;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | JWT Authentication Secret
+    |--------------------------------------------------------------------------
+    |
+    | Don't forget to set this in your .env file, as it will be used to sign
+    | your tokens. A helper command is provided for this:
+    | `php artisan jwt:secret`
+    |
+    | Note: This will be used for Symmetric algorithms only (HMAC),
+    | since RSA and ECDSA use a private/public key combo (See below).
+    |
+    */
+
+    'secret' => env('JWT_SECRET'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT Authentication Keys
+    |--------------------------------------------------------------------------
+    |
+    | The algorithm you are using, will determine whether your tokens are
+    | signed with a random string (defined in `JWT_SECRET`) or using the
+    | following public & private keys.
+    |
+    | Symmetric Algorithms:
+    | HS256, HS384 & HS512 will use `JWT_SECRET`.
+    |
+    | Asymmetric Algorithms:
+    | RS256, RS384 & RS512 / ES256, ES384 & ES512 will use the keys below.
+    |
+    */
+
+    'keys' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Public Key
+        |--------------------------------------------------------------------------
+        |
+        | A path or resource to your public key.
+        |
+        | E.g. 'file://path/to/public/key'
+        |
+        */
+
+        'public' => env('JWT_PUBLIC_KEY'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Private Key
+        |--------------------------------------------------------------------------
+        |
+        | A path or resource to your private key.
+        |
+        | E.g. 'file://path/to/private/key'
+        |
+        */
+
+        'private' => env('JWT_PRIVATE_KEY'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Passphrase
+        |--------------------------------------------------------------------------
+        |
+        | The passphrase for your private key. Can be null if none set.
+        |
+        */
+
+        'passphrase' => env('JWT_PASSPHRASE'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT time to live
+    |--------------------------------------------------------------------------
+    |
+    | Specify the length of time (in minutes) that the token will be valid for.
+    | Defaults to 1 hour.
+    |
+    | You can also set this to null, to yield a never expiring token.
+    | Some people may want this behaviour for e.g. a mobile app.
+    | This is not particularly recommended, so make sure you have appropriate
+    | systems in place to revoke the token if necessary.
+    | Notice: If you set this to null you should remove 'exp' element from 'required_claims' list.
+    |
+    */
+
+    'ttl' => (int) env('JWT_TTL', 60),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Refresh time to live
+    |--------------------------------------------------------------------------
+    |
+    | Specify the length of time (in minutes) that the token can be refreshed within.
+    | This defines the refresh window, during which the user can refresh their token
+    | before re-authentication is required.
+    |
+    | By default, a refresh will NOT issue a new "iat" (issued at) timestamp. If changed
+    | to true, each refresh will issue a new "iat" timestamp, extending the refresh
+    | period from the most recent refresh. This results in a rolling refresh
+    |
+    | To retain a fluid refresh window from the last refresh action (i.e., the behavior between
+    | version 2.5.0 and 2.8.2), set "refresh_iat" to true. With this setting, the refresh
+    | window will renew with each subsequent refresh.
+    |
+    | The refresh ttl defaults to 2 weeks.
+    |
+    | You can also set this to null, to yield an infinite refresh time.
+    | Some may want this instead of never expiring tokens for e.g. a mobile app.
+    | This is not particularly recommended, so make sure you have appropriate
+    | systems in place to revoke the token if necessary.
+    |
+    */
+
+    'refresh_iat' => env('JWT_REFRESH_IAT', false),
+    'refresh_ttl' => (int) env('JWT_REFRESH_TTL', 20160),
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT hashing algorithm
+    |--------------------------------------------------------------------------
+    |
+    | Specify the hashing algorithm that will be used to sign the token.
+    |
+    | See here: https://github.com/namshi/jose/tree/master/src/Namshi/JOSE/Signer/OpenSSL
+    | for possible values.
+    |
+    */
+
+    'algo' => env('JWT_ALGO', 'HS256'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Required Claims
+    |--------------------------------------------------------------------------
+    |
+    | Specify the required claims that must exist in any token.
+    | A TokenInvalidException will be thrown if any of these claims are not
+    | present in the payload.
+    |
+    */
+
+    'required_claims' => [
+        'iss',
+        'iat',
+        'exp',
+        'nbf',
+        'sub',
+        'jti',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Persistent Claims
+    |--------------------------------------------------------------------------
+    |
+    | Specify the claim keys to be persisted when refreshing a token.
+    | `sub` and `iat` will automatically be persisted, in
+    | addition to the these claims.
+    |
+    | Note: If a claim does not exist then it will be ignored.
+    |
+    */
+
+    'persistent_claims' => [
+        // 'foo',
+        // 'bar',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Lock Subject
+    |--------------------------------------------------------------------------
+    |
+    | This will determine whether a `prv` claim is automatically added to
+    | the token. The purpose of this is to ensure that if you have multiple
+    | authentication models e.g. `App\User` & `App\OtherPerson`, then we
+    | should prevent one authentication request from impersonating another,
+    | if 2 tokens happen to have the same id across the 2 different models.
+    |
+    | Under specific circumstances, you may want to disable this behaviour
+    | e.g. if you only have one authentication model, then you would save
+    | a little on token size.
+    |
+    */
+
+    'lock_subject' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Leeway
+    |--------------------------------------------------------------------------
+    |
+    | This property gives the jwt timestamp claims some "leeway".
+    | Meaning that if you have any unavoidable slight clock skew on
+    | any of your servers then this will afford you some level of cushioning.
+    |
+    | This applies to the claims `iat`, `nbf` and `exp`.
+    |
+    | Specify in seconds - only if you know you need it.
+    |
+    */
+
+    'leeway' => (int) env('JWT_LEEWAY', 0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Blacklist Enabled
+    |--------------------------------------------------------------------------
+    |
+    | In order to invalidate tokens, you must have the blacklist enabled.
+    | If you do not want or need this functionality, then set this to false.
+    |
+    */
+
+    'blacklist_enabled' => env('JWT_BLACKLIST_ENABLED', true),
+
+    /*
+    | -------------------------------------------------------------------------
+    | Blacklist Grace Period
+    | -------------------------------------------------------------------------
+    |
+    | When multiple concurrent requests are made with the same JWT,
+    | it is possible that some of them fail, due to token regeneration
+    | on every request.
+    |
+    | Set grace period in seconds to prevent parallel request failure.
+    |
+    */
+
+    'blacklist_grace_period' => (int) env('JWT_BLACKLIST_GRACE_PERIOD', 0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Show blacklisted token option
+    |--------------------------------------------------------------------------
+    |
+    | Specify if you want to show black listed token exception on the laravel logs.
+    |
+    */
+
+    'show_black_list_exception' => env('JWT_SHOW_BLACKLIST_EXCEPTION', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cookies encryption
+    |--------------------------------------------------------------------------
+    |
+    | By default Laravel encrypt cookies for security reason.
+    | If you decide to not decrypt cookies, you will have to configure Laravel
+    | to not encrypt your cookie token by adding its name into the $except
+    | array available in the middleware "EncryptCookies" provided by Laravel.
+    | see https://laravel.com/docs/master/responses#cookies-and-encryption
+    | for details.
+    |
+    | Set it to true if you want to decrypt cookies.
+    |
+    */
+
+    'decrypt_cookies' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cookie key name
+    |--------------------------------------------------------------------------
+    |
+    | Specify the cookie key name that you would like to use for the cookie token.
+    |
+    */
+
+    'cookie_key_name' => 'token',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Providers
+    |--------------------------------------------------------------------------
+    |
+    | Specify the various providers used throughout the package.
+    |
+    */
+
+    'providers' => [
+        /*
+        |--------------------------------------------------------------------------
+        | JWT Provider
+        |--------------------------------------------------------------------------
+        |
+        | Specify the provider that is used to create and decode the tokens.
+        |
+        */
+
+        'jwt' => Lcobucci::class,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Authentication Provider
+        |--------------------------------------------------------------------------
+        |
+        | Specify the provider that is used to authenticate users.
+        |
+        */
+
+        'auth' => Illuminate::class,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Storage Provider
+        |--------------------------------------------------------------------------
+        |
+        | Specify the provider that is used to store tokens in the blacklist.
+        |
+        */
+
+        'storage' => PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate::class,
+    ],
+];

--- a/cinemap-app/database/migrations/2026_04_17_121206_create_customer_columns.php
+++ b/cinemap-app/database/migrations/2026_04_17_121206_create_customer_columns.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('stripe_id')->nullable()->index();
+            $table->string('pm_type')->nullable();
+            $table->string('pm_last_four', 4)->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex([
+                'stripe_id',
+            ]);
+
+            $table->dropColumn([
+                'stripe_id',
+                'pm_type',
+                'pm_last_four',
+                'trial_ends_at',
+            ]);
+        });
+    }
+};

--- a/cinemap-app/database/migrations/2026_04_17_121207_create_subscriptions_table.php
+++ b/cinemap-app/database/migrations/2026_04_17_121207_create_subscriptions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->string('type');
+            $table->string('stripe_id')->unique();
+            $table->string('stripe_status');
+            $table->string('stripe_price')->nullable();
+            $table->integer('quantity')->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'stripe_status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/cinemap-app/database/migrations/2026_04_17_121208_create_subscription_items_table.php
+++ b/cinemap-app/database/migrations/2026_04_17_121208_create_subscription_items_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscription_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('subscription_id');
+            $table->string('stripe_id')->unique();
+            $table->string('stripe_product');
+            $table->string('stripe_price');
+            $table->integer('quantity')->nullable();
+            $table->timestamps();
+
+            $table->index(['subscription_id', 'stripe_price']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscription_items');
+    }
+};

--- a/cinemap-app/database/migrations/2026_04_17_121209_add_meter_id_to_subscription_items_table.php
+++ b/cinemap-app/database/migrations/2026_04_17_121209_add_meter_id_to_subscription_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->string('meter_id')->nullable()->after('stripe_price');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->dropColumn('meter_id');
+        });
+    }
+};

--- a/cinemap-app/database/migrations/2026_04_17_121210_add_meter_event_name_to_subscription_items_table.php
+++ b/cinemap-app/database/migrations/2026_04_17_121210_add_meter_event_name_to_subscription_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->string('meter_event_name')->nullable()->after('quantity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->dropColumn('meter_event_name');
+        });
+    }
+};

--- a/cinemap-app/resources/views/auth/login.blade.php
+++ b/cinemap-app/resources/views/auth/login.blade.php
@@ -22,23 +22,23 @@
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
 
-        <!-- Remember Me -->
-        <div class="block mt-4">
+        <!-- Remember Me + Forgot password -->
+        <div class="flex items-center justify-between mt-4">
             <label for="remember_me" class="inline-flex items-center">
                 <input id="remember_me" type="checkbox" class="rounded dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:focus:ring-offset-gray-800" name="remember">
                 <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">{{ __('Remember me') }}</span>
             </label>
-        </div>
 
-        <div class="flex items-center justify-between mt-4">
             @if (Route::has('password.request'))
                 <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
                    href="{{ route('password.request') }}">
                     {{ __('Forgot your password?') }}
                 </a>
             @endif
+        </div>
 
-            <x-primary-button>
+        <div class="mt-4">
+            <x-primary-button class="w-full justify-center">
                 {{ __('Log in') }}
             </x-primary-button>
         </div>

--- a/cinemap-app/resources/views/layouts/navigation.blade.php
+++ b/cinemap-app/resources/views/layouts/navigation.blade.php
@@ -16,6 +16,9 @@
                         Accueil
                     </x-nav-link>
                     @auth
+                    <x-nav-link :href="route('subscription.index')" :active="request()->routeIs('subscription.index')">
+                        Abonnement
+                    </x-nav-link>
                     @if (auth()->user()->is_admin)
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         Dashboard

--- a/cinemap-app/resources/views/subscription/index.blade.php
+++ b/cinemap-app/resources/views/subscription/index.blade.php
@@ -1,0 +1,108 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Abonnement CineMap
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-lg mx-auto sm:px-6 lg:px-8">
+
+            @if (session('success'))
+                <div class="mb-6 p-4 bg-green-100 text-green-800 rounded-lg">
+                    {{ session('success') }}
+                </div>
+            @endif
+
+            <!-- Card tarif -->
+            <div class="bg-white dark:bg-gray-800 shadow-sm sm:rounded-lg overflow-hidden mb-6">
+                <div class="bg-indigo-600 px-6 py-5">
+                    <h3 class="text-white text-lg font-bold">Abonnement Premium</h3>
+                    <p class="text-indigo-200 text-sm mt-1">Accès à l'API JSON CineMap</p>
+                </div>
+                <div class="px-6 py-4">
+                    <div class="flex items-baseline gap-1 mb-4">
+                        <span class="text-3xl font-bold text-gray-900 dark:text-white">5 €</span>
+                        <span class="text-gray-500 dark:text-gray-400">/ mois</span>
+                    </div>
+                    <ul class="space-y-2 text-sm text-gray-600 dark:text-gray-400 mb-6">
+                        <li class="flex items-center gap-2">
+                            <span class="text-green-500 font-bold">✓</span> Accès à l'API <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">GET /api/films/{film}/locations</code>
+                        </li>
+                        <li class="flex items-center gap-2">
+                            <span class="text-green-500 font-bold">✓</span> Authentification JWT
+                        </li>
+                        <li class="flex items-center gap-2">
+                            <span class="text-green-500 font-bold">✓</span> Résiliation à tout moment
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Formulaire paiement -->
+            <div class="bg-white dark:bg-gray-800 shadow-sm sm:rounded-lg px-6 py-6">
+                <h4 class="text-gray-800 dark:text-gray-200 font-semibold mb-4">Informations de paiement</h4>
+
+                <form id="payment-form" action="{{ route('subscription.store') }}" method="POST">
+                    @csrf
+                    <input type="hidden" name="payment_method" id="payment_method">
+
+                    <div class="mb-4">
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                            Carte bancaire
+                        </label>
+                        <div id="card-element"
+                             class="p-3 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-200">
+                        </div>
+                        <p id="card-errors" class="mt-2 text-sm text-red-600"></p>
+                    </div>
+
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                        Carte de test : <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">4242 4242 4242 4242</code> — date future, CVC quelconque.
+                    </p>
+
+                    <button type="submit" id="submit-btn"
+                        class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2.5 px-4 rounded-md transition disabled:opacity-50">
+                        S'abonner — 5 €/mois
+                    </button>
+                </form>
+            </div>
+
+        </div>
+    </div>
+
+    <script src="https://js.stripe.com/v3/"></script>
+    <script>
+        const stripe = Stripe('{{ config('cashier.key') }}');
+        const elements = stripe.elements();
+        const cardElement = elements.create('card', {
+            style: {
+                base: { fontSize: '16px', color: '#374151' }
+            }
+        });
+        cardElement.mount('#card-element');
+
+        const form = document.getElementById('payment-form');
+        const submitBtn = document.getElementById('submit-btn');
+
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Traitement en cours...';
+
+            const { setupIntent, error } = await stripe.confirmCardSetup(
+                '{{ $intent->client_secret }}',
+                { payment_method: { card: cardElement } }
+            );
+
+            if (error) {
+                document.getElementById('card-errors').textContent = error.message;
+                submitBtn.disabled = false;
+                submitBtn.textContent = "S'abonner — 5 €/mois";
+            } else {
+                document.getElementById('payment_method').value = setupIntent.payment_method;
+                form.submit();
+            }
+        });
+    </script>
+</x-app-layout>

--- a/cinemap-app/resources/views/subscription/index.blade.php
+++ b/cinemap-app/resources/views/subscription/index.blade.php
@@ -14,18 +14,31 @@
                 </div>
             @endif
 
+            @if (session('error'))
+                <div class="mb-6 p-4 bg-red-100 text-red-800 rounded-lg">
+                    {{ session('error') }}
+                </div>
+            @endif
+
             <!-- Card tarif -->
             <div class="bg-white dark:bg-gray-800 shadow-sm sm:rounded-lg overflow-hidden mb-6">
-                <div class="bg-indigo-600 px-6 py-5">
-                    <h3 class="text-white text-lg font-bold">Abonnement Premium</h3>
-                    <p class="text-indigo-200 text-sm mt-1">Accès à l'API JSON CineMap</p>
+                <div class="bg-indigo-600 px-6 py-5 flex items-center justify-between">
+                    <div>
+                        <h3 class="text-white text-lg font-bold">Abonnement Premium</h3>
+                        <p class="text-indigo-200 text-sm mt-1">Accès à l'API JSON CineMap</p>
+                    </div>
+                    @if ($subscribed)
+                        <span class="bg-green-400 text-white text-xs font-bold px-3 py-1 rounded-full">
+                            Actif
+                        </span>
+                    @endif
                 </div>
                 <div class="px-6 py-4">
                     <div class="flex items-baseline gap-1 mb-4">
                         <span class="text-3xl font-bold text-gray-900 dark:text-white">5 €</span>
                         <span class="text-gray-500 dark:text-gray-400">/ mois</span>
                     </div>
-                    <ul class="space-y-2 text-sm text-gray-600 dark:text-gray-400 mb-6">
+                    <ul class="space-y-2 text-sm text-gray-600 dark:text-gray-400 mb-2">
                         <li class="flex items-center gap-2">
                             <span class="text-green-500 font-bold">✓</span> Accès à l'API <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">GET /api/films/{film}/locations</code>
                         </li>
@@ -40,7 +53,17 @@
             </div>
 
             <!-- Formulaire paiement -->
-            <div class="bg-white dark:bg-gray-800 shadow-sm sm:rounded-lg px-6 py-6">
+            <div class="bg-white dark:bg-gray-800 shadow-sm sm:rounded-lg px-6 py-6 {{ $subscribed ? 'opacity-50 pointer-events-none select-none' : '' }}">
+
+                @if ($subscribed)
+                    <div class="flex items-center gap-2 mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-md">
+                        <span class="text-green-600 font-bold text-lg">✓</span>
+                        <p class="text-green-700 dark:text-green-400 text-sm font-medium">
+                            Vous êtes déjà abonné. Le formulaire de paiement est désactivé.
+                        </p>
+                    </div>
+                @endif
+
                 <h4 class="text-gray-800 dark:text-gray-200 font-semibold mb-4">Informations de paiement</h4>
 
                 <form id="payment-form" action="{{ route('subscription.store') }}" method="POST">
@@ -61,9 +84,9 @@
                         Carte de test : <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">4242 4242 4242 4242</code> — date future, CVC quelconque.
                     </p>
 
-                    <button type="submit" id="submit-btn"
-                        class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2.5 px-4 rounded-md transition disabled:opacity-50">
-                        S'abonner — 5 €/mois
+                    <button type="submit" id="submit-btn" {{ $subscribed ? 'disabled' : '' }}
+                        class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2.5 px-4 rounded-md transition disabled:opacity-50 disabled:cursor-not-allowed">
+                        {{ $subscribed ? 'Déjà abonné' : "S'abonner — 5 €/mois" }}
                     </button>
                 </form>
             </div>
@@ -71,38 +94,40 @@
         </div>
     </div>
 
-    <script src="https://js.stripe.com/v3/"></script>
-    <script>
-        const stripe = Stripe('{{ config('cashier.key') }}');
-        const elements = stripe.elements();
-        const cardElement = elements.create('card', {
-            style: {
-                base: { fontSize: '16px', color: '#374151' }
-            }
-        });
-        cardElement.mount('#card-element');
+    @if (!$subscribed)
+        <script src="https://js.stripe.com/v3/"></script>
+        <script>
+            const stripe = Stripe('{{ config('cashier.key') }}');
+            const elements = stripe.elements();
+            const cardElement = elements.create('card', {
+                style: {
+                    base: { fontSize: '16px', color: '#374151' }
+                }
+            });
+            cardElement.mount('#card-element');
 
-        const form = document.getElementById('payment-form');
-        const submitBtn = document.getElementById('submit-btn');
+            const form = document.getElementById('payment-form');
+            const submitBtn = document.getElementById('submit-btn');
 
-        form.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            submitBtn.disabled = true;
-            submitBtn.textContent = 'Traitement en cours...';
+            form.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                submitBtn.disabled = true;
+                submitBtn.textContent = 'Traitement en cours...';
 
-            const { setupIntent, error } = await stripe.confirmCardSetup(
-                '{{ $intent->client_secret }}',
-                { payment_method: { card: cardElement } }
-            );
+                const { setupIntent, error } = await stripe.confirmCardSetup(
+                    '{{ $intent->client_secret }}',
+                    { payment_method: { card: cardElement } }
+                );
 
-            if (error) {
-                document.getElementById('card-errors').textContent = error.message;
-                submitBtn.disabled = false;
-                submitBtn.textContent = "S'abonner — 5 €/mois";
-            } else {
-                document.getElementById('payment_method').value = setupIntent.payment_method;
-                form.submit();
-            }
-        });
-    </script>
+                if (error) {
+                    document.getElementById('card-errors').textContent = error.message;
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = "S'abonner — 5 €/mois";
+                } else {
+                    document.getElementById('payment_method').value = setupIntent.payment_method;
+                    form.submit();
+                }
+            });
+        </script>
+    @endif
 </x-app-layout>

--- a/cinemap-app/routes/api.php
+++ b/cinemap-app/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Http\Controllers\ApiAuthController;
+use App\Http\Controllers\FilmApiController;
+use Illuminate\Support\Facades\Route;
+
+// routes/api.php
+Route::post('/auth/login', [ApiAuthController::class, 'login']);
+Route::middleware('auth:api')->group(function () {
+    Route::get('/films/{film}/locations', [FilmApiController::class, 'locations']);
+});

--- a/cinemap-app/routes/web.php
+++ b/cinemap-app/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\LocalisationController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\SocialiteController;
+use App\Http\Controllers\SubscriptionController;
 use App\Models\Film;
 use App\Models\Localisation;
 use Illuminate\Support\Facades\Route;
@@ -39,8 +40,13 @@ Route::middleware('auth')->group(function () {
     Route::put('/localisations/{localisation}', [LocalisationController::class, 'update'])->name('localisations.update');
     Route::delete('/localisations/{localisation}', [LocalisationController::class, 'destroy'])->name('localisations.destroy');
 
+    // Votes — actions utilisateur (sur toutes les localisations/films)
     Route::post('/localisations/{localisation}/vote', [LocalisationController::class, 'vote'])->name('localisations.vote');
     Route::post('/films/{film}/vote', [FilmController::class, 'vote'])->name('films.vote');
+
+    // Abonnement
+    Route::get('/subscription', [SubscriptionController::class, 'index'])->name('subscription.index');
+    Route::post('/subscription', [SubscriptionController::class, 'store'])->name('subscription.store');
 });
 
 // Dashboard — réservé aux admins

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1168,15 +1168,15 @@ Route::get('/auth/discord/callback', [SocialiteController::class, 'handleDiscord
 ### Route attendue
 
 ```
-GET /api/films/{film}/locations
-Authorization: Bearer <token_jwt>
+POST /api/auth/login       → retourne un token JWT
+GET  /api/films/{film}/locations   Authorization: Bearer <token>
 ```
 
-### Ce qu'il faut faire
+---
 
-#### Stripe
+### Partie A — Stripe (abonnement)
 
-1. Installer Cashier :
+#### 1. Installer Cashier
 
 ```bash
 composer require laravel/cashier
@@ -1184,53 +1184,48 @@ php artisan vendor:publish --tag="cashier-migrations"
 php artisan migrate
 ```
 
-Cela crée les tables `subscriptions`, `subscription_items` et ajoute des colonnes sur `users`.
+> Si `vendor:publish` est lancé deux fois, des migrations en double apparaissent. Supprimer manuellement les fichiers en double dans `database/migrations/` puis relancer `php artisan migrate:fresh --seed`.
 
-2. Créer un compte Stripe et récupérer les clés
+> Si l'extension PHP `bcmath` est manquante : `sudo apt install php8.3-bcmath`
 
-- Aller sur https://dashboard.stripe.com → crée un compte
-- Dans le menu gauche Developers → API keys
-- Copier Publishable key et Secret key (mode test)
+#### 2. Créer un compte Stripe et récupérer les clés
 
-Dans .env :
+- Aller sur https://dashboard.stripe.com → créer un compte
+- Menu gauche **Developers → API keys** → copier **Publishable key** et **Secret key** (mode test)
+
 ```env
 STRIPE_KEY=pk_test_...
 STRIPE_SECRET=sk_test_...
 ```
 
-3. Ajouter le trait `Billable` au modèle `User`.
+#### 3. Ajouter le trait `Billable` au modèle `User`
 
 ```php
-// app/Models/User.php — ajouter l'import et le trait
 use Laravel\Cashier\Billable;
 
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable, Billable;
-
+    use Billable, HasFactory, Notifiable;
+}
 ```
 
-4. Créer un produit/prix dans Stripe
+#### 4. Créer un produit dans Stripe
 
-- Dans le dashboard Stripe → Products → Add product
-- Nom : `Abonnement CineMap`, prix : ex. `5.00 € / mois`, type Recurring
-- Après création, copier le Price ID (commence par price_...)
+- Dashboard Stripe → **Products → Add product**
+- Nom : `Abonnement CineMap`, prix : `5.00 €/mois`, type **Recurring**
+- Après création, copier le **Price ID** (`price_...`)
 
-Dans .env :
 ```env
 STRIPE_PRICE_ID=price_...
 ```
 
-5. Créer une page de souscription simple avec un formulaire Stripe.
-
-Il faut 3 choses : une route, un controller, une vue.
+#### 5. Créer le `SubscriptionController`
 
 ```bash
 php artisan make:controller SubscriptionController
 ```
 
 ```php
-// SubscriptionController
 use Illuminate\Http\Request;
 
 public function index()
@@ -1245,11 +1240,8 @@ public function store(Request $request)
     $request->validate(['payment_method' => 'required']);
 
     $user = auth()->user();
-
     $user->createOrGetStripeCustomer();
-
     $user->addPaymentMethod($request->payment_method);
-
     $user->newSubscription('default', env('STRIPE_PRICE_ID'))
         ->create($request->payment_method);
 
@@ -1257,66 +1249,22 @@ public function store(Request $request)
 }
 ```
 
-Route dans web.php (dans le groupe middleware('auth')) :
+Routes dans `web.php` (groupe `middleware('auth')`) :
 
 ```php
 Route::get('/subscription', [SubscriptionController::class, 'index'])->name('subscription.index');
 Route::post('/subscription', [SubscriptionController::class, 'store'])->name('subscription.store');
 ```
 
-Vue resources/views/subscription/index.blade.php avec le formulaire Stripe.js :
+#### 6. Tester
 
-```php
-<x-app-layout>
-    <x-slot name="header">Abonnement</x-slot>
+Carte de test Stripe : `4242 4242 4242 4242` — date future, CVC quelconque.
 
-    <div class="py-12 max-w-xl mx-auto">
-        <form id="payment-form" action="{{ route('subscription.store') }}" method="POST">
-            @csrf
-            <input type="hidden" name="payment_method" id="payment_method">
+---
 
-            <div id="card-element" class="p-3 border rounded mb-4"></div>
-            <p id="card-errors" class="text-red-500 text-sm mb-4"></p>
+### Partie B — JWT (API protégée)
 
-            <button type="submit"
-                class="w-full bg-blue-600 text-white font-semibold py-2 px-4 rounded hover:bg-blue-700">
-                S'abonner — 5 €/mois
-            </button>
-        </form>
-    </div>
-
-    <script src="https://js.stripe.com/v3/"></script>
-    <script>
-        const stripe = Stripe('{{ config('cashier.key') }}');
-        const elements = stripe.elements();
-        const cardElement = elements.create('card');
-        cardElement.mount('#card-element');
-
-        const form = document.getElementById('payment-form');
-        form.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const { setupIntent, error } = await stripe.confirmCardSetup(
-                '{{ $intent->client_secret }}',
-                { payment_method: { card: cardElement } }
-            );
-            if (error) {
-                document.getElementById('card-errors').textContent = error.message;
-            } else {
-                document.getElementById('payment_method').value = setupIntent.payment_method;
-                form.submit();
-            }
-        });
-    </script>
-</x-app-layout>
-```
-
-6. Tester
-
-Carte de test Stripe : `4242 4242 4242 4242` — date future, CVC n'importe lequel.
-
-#### JWT
-
-1. Installer `php-open-source-saver/jwt-auth` :
+#### 1. Installer jwt-auth
 
 ```bash
 composer require php-open-source-saver/jwt-auth
@@ -1324,23 +1272,129 @@ php artisan vendor:publish --provider="PHPOpenSourceSaver\JWTAuth\Providers\Lara
 php artisan jwt:secret
 ```
 
-2. Ajouter dans `.env` :
+Le secret est ajouté automatiquement dans `.env` sous `JWT_SECRET`.
 
-```env
-JWT_SECRET=<valeur générée>
-```
-
-3. Créer les routes d'auth API :
+#### 2. Configurer le guard `api` dans `config/auth.php`
 
 ```php
-// routes/api.php
+'guards' => [
+    'web' => ['driver' => 'session', 'provider' => 'users'],
+    'api' => ['driver' => 'jwt',     'provider' => 'users'],
+],
+```
+
+#### 3. Implémenter `JWTSubject` sur le modèle `User`
+
+```php
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
+
+class User extends Authenticatable implements JWTSubject
+{
+    public function getJWTIdentifier(): mixed
+    {
+        return $this->getKey();
+    }
+
+    public function getJWTCustomClaims(): array
+    {
+        return [];
+    }
+}
+```
+
+#### 4. Créer les controllers API
+
+```bash
+php artisan make:controller ApiAuthController
+php artisan make:controller FilmApiController
+```
+
+**`ApiAuthController`** — vérifie les credentials ET l'abonnement avant de délivrer le token :
+
+```php
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+public function login(Request $request)
+{
+    $credentials = $request->validate([
+        'email'    => 'required|email',
+        'password' => 'required',
+    ]);
+
+    if (! $token = Auth::guard('api')->attempt($credentials)) {
+        return response()->json(['error' => 'Identifiants invalides'], 401);
+    }
+
+    $user = Auth::guard('api')->user();
+
+    if (! $user->subscribed('default')) {
+        Auth::guard('api')->logout();
+        return response()->json(['error' => 'Abonnement requis'], 403);
+    }
+
+    return response()->json(['token' => $token]);
+}
+```
+
+**`FilmApiController`** — retourne le film et ses localisations en JSON :
+
+```php
+use App\Models\Film;
+
+public function locations(Film $film)
+{
+    return response()->json([
+        'film'          => $film->only(['id', 'name', 'producer', 'release_year', 'synopsis']),
+        'localisations' => $film->localisations()->get([
+            'id', 'name', 'city', 'country', 'description', 'upvotes_count',
+        ]),
+    ]);
+}
+```
+
+#### 5. Enregistrer `routes/api.php` dans `bootstrap/app.php`
+
+> **Laravel 11+ ne charge pas `routes/api.php` automatiquement.** Sans cette étape, toutes les routes API retournent 404.
+
+```php
+// bootstrap/app.php
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web:      __DIR__.'/../routes/web.php',
+        api:      __DIR__.'/../routes/api.php',   // ← obligatoire
+        commands: __DIR__.'/../routes/console.php',
+        health:   '/up',
+    )
+    // ...
+```
+
+#### 6. Déclarer les routes dans `routes/api.php`
+
+```php
+use App\Http\Controllers\ApiAuthController;
+use App\Http\Controllers\FilmApiController;
+
 Route::post('/auth/login', [ApiAuthController::class, 'login']);
-Route::middleware(['auth:api', 'subscribed'])->group(function () {
+
+Route::middleware('auth:api')->group(function () {
     Route::get('/films/{film}/locations', [FilmApiController::class, 'locations']);
 });
 ```
 
-4. La réponse JSON doit contenir : infos du film + liste des emplacements + `upvotes_count`.
+> Ne pas ajouter de middleware `subscribed` — il n'existe pas. La vérification de l'abonnement est faite dans `ApiAuthController@login` avant de délivrer le token.
+
+#### 7. Tester avec curl
+
+```bash
+curl -s -X POST http://localhost:8000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"ton@email.com","password":"motdepasse"}' | jq .
+
+# Puis avec le token :
+curl -s http://localhost:8000/api/films/1/locations \
+  -H "Authorization: Bearer <token>" | jq .
+```
 
 ---
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1316,7 +1316,7 @@ Carte de test Stripe : `4242 4242 4242 4242` — date future, CVC n'importe lequ
 
 #### JWT
 
-1. Installer `php-open-source-saver/jwt-auth` (compatible Laravel 11) :
+1. Installer `php-open-source-saver/jwt-auth` :
 
 ```bash
 composer require php-open-source-saver/jwt-auth

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1184,11 +1184,135 @@ php artisan vendor:publish --tag="cashier-migrations"
 php artisan migrate
 ```
 
-2. Ajouter le trait `Billable` au modèle `User`.
+Cela crée les tables `subscriptions`, `subscription_items` et ajoute des colonnes sur `users`.
 
-3. Créer une page de souscription simple avec un formulaire Stripe.
+2. Créer un compte Stripe et récupérer les clés
 
-4. Tester avec la carte `4242 4242 4242 4242`.
+- Aller sur https://dashboard.stripe.com → crée un compte
+- Dans le menu gauche Developers → API keys
+- Copier Publishable key et Secret key (mode test)
+
+Dans .env :
+```env
+STRIPE_KEY=pk_test_...
+STRIPE_SECRET=sk_test_...
+```
+
+3. Ajouter le trait `Billable` au modèle `User`.
+
+```php
+// app/Models/User.php — ajouter l'import et le trait
+use Laravel\Cashier\Billable;
+
+class User extends Authenticatable
+{
+    use HasFactory, Notifiable, Billable;
+
+```
+
+4. Créer un produit/prix dans Stripe
+
+- Dans le dashboard Stripe → Products → Add product
+- Nom : `Abonnement CineMap`, prix : ex. `5.00 € / mois`, type Recurring
+- Après création, copier le Price ID (commence par price_...)
+
+Dans .env :
+```env
+STRIPE_PRICE_ID=price_...
+```
+
+5. Créer une page de souscription simple avec un formulaire Stripe.
+
+Il faut 3 choses : une route, un controller, une vue.
+
+```bash
+php artisan make:controller SubscriptionController
+```
+
+```php
+// SubscriptionController
+use Illuminate\Http\Request;
+
+public function index()
+{
+    return view('subscription.index', [
+        'intent' => auth()->user()->createSetupIntent(),
+    ]);
+}
+
+public function store(Request $request)
+{
+    $request->validate(['payment_method' => 'required']);
+
+    $user = auth()->user();
+
+    $user->createOrGetStripeCustomer();
+
+    $user->addPaymentMethod($request->payment_method);
+
+    $user->newSubscription('default', env('STRIPE_PRICE_ID'))
+        ->create($request->payment_method);
+
+    return redirect('/home')->with('success', 'Abonnement activé !');
+}
+```
+
+Route dans web.php (dans le groupe middleware('auth')) :
+
+```php
+Route::get('/subscription', [SubscriptionController::class, 'index'])->name('subscription.index');
+Route::post('/subscription', [SubscriptionController::class, 'store'])->name('subscription.store');
+```
+
+Vue resources/views/subscription/index.blade.php avec le formulaire Stripe.js :
+
+```php
+<x-app-layout>
+    <x-slot name="header">Abonnement</x-slot>
+
+    <div class="py-12 max-w-xl mx-auto">
+        <form id="payment-form" action="{{ route('subscription.store') }}" method="POST">
+            @csrf
+            <input type="hidden" name="payment_method" id="payment_method">
+
+            <div id="card-element" class="p-3 border rounded mb-4"></div>
+            <p id="card-errors" class="text-red-500 text-sm mb-4"></p>
+
+            <button type="submit"
+                class="w-full bg-blue-600 text-white font-semibold py-2 px-4 rounded hover:bg-blue-700">
+                S'abonner — 5 €/mois
+            </button>
+        </form>
+    </div>
+
+    <script src="https://js.stripe.com/v3/"></script>
+    <script>
+        const stripe = Stripe('{{ config('cashier.key') }}');
+        const elements = stripe.elements();
+        const cardElement = elements.create('card');
+        cardElement.mount('#card-element');
+
+        const form = document.getElementById('payment-form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const { setupIntent, error } = await stripe.confirmCardSetup(
+                '{{ $intent->client_secret }}',
+                { payment_method: { card: cardElement } }
+            );
+            if (error) {
+                document.getElementById('card-errors').textContent = error.message;
+            } else {
+                document.getElementById('payment_method').value = setupIntent.payment_method;
+                form.submit();
+            }
+        });
+    </script>
+</x-app-layout>
+```
+
+6. Tester
+
+Carte de test Stripe : `4242 4242 4242 4242` — date future, CVC n'importe lequel.
 
 #### JWT
 
@@ -1217,15 +1341,6 @@ Route::middleware(['auth:api', 'subscribed'])->group(function () {
 ```
 
 4. La réponse JSON doit contenir : infos du film + liste des emplacements + `upvotes_count`.
-
-### Checklist
-
-- [ ] Stripe fonctionnel en mode test (carte `4242 4242 4242 4242`)
-- [ ] Page de souscription accessible
-- [ ] `JWT_SECRET` généré et configuré
-- [ ] Route `POST /api/auth/login` retourne un token JWT
-- [ ] Route `GET /api/films/{film}/locations` accessible uniquement avec JWT valide + abonnement actif
-- [ ] Réponse JSON contient les infos du film et ses emplacements
 
 ---
 


### PR DESCRIPTION
## [0.8.0] - 17/04/2026

### Ajouté

- Package `laravel/cashier` installé (abonnements Stripe récurrents)
- Trait `Billable` ajouté au modèle `User`
- Migrations Cashier publiées (`vendor:publish --tag="cashier-migrations"`) et appliquées : colonnes Stripe sur `users` + table `subscriptions`
- Variables `.env` : `STRIPE_KEY`, `STRIPE_SECRET`, `STRIPE_PRICE_ID`
- Produit et prix récurrent créé dans le dashboard Stripe (`5 €/mois`)
- `SubscriptionController` avec `index` (page abonnement) et `store` (souscription via `newSubscription`)
- Vue `subscription/index.blade.php` : card tarif + formulaire Stripe Elements (SetupIntent)
- Si l'utilisateur est déjà abonné : formulaire grisé (`opacity-50 pointer-events-none`), bouton désactivé, JS Stripe non chargé
- Routes `GET /subscription` et `POST /subscription` dans le groupe `middleware('auth')`
- Package `php-open-source-saver/jwt-auth` installé
- Config JWT publiée (`vendor:publish --provider="PHPOpenSourceSaver\JWTAuth\..."`) et secret généré (`php artisan jwt:secret` → `JWT_SECRET` dans `.env`)
- Guard `api` avec driver `jwt` dans `config/auth.php`
- Interface `JWTSubject` implémentée sur `User` (`getJWTIdentifier`, `getJWTCustomClaims`)
- `ApiAuthController@login` : vérifie les credentials ET l'abonnement avant de délivrer le token JWT (401 si mauvais credentials, 403 si non abonné)
- `FilmApiController@locations` : retourne le film et ses localisations en JSON (champs sélectifs)
- `routes/api.php` déclaré avec `Route::post('/auth/login')` public et `GET /films/{film}/locations` protégé par `middleware('auth:api')`
- `routes/api.php` enregistré dans `bootstrap/app.php` (obligatoire en Laravel 11 — non chargé automatiquement)

### Corrigé

- `ext-bcmath` manquant : `sudo apt install php8.3-bcmath` requis par Cashier v16
- Migrations Cashier en double (double `vendor:publish`) : suppression du second jeu de fichiers + `migrate:fresh --seed`
- `STRIPE_PRICE_ID` non renseigné dans `.env` → `newSubscription()` recevait `null` — corrigé en ajoutant la variable
- `GET /api/films/1/locations` retournait 404 en Laravel 11 : `routes/api.php` n'est pas auto-chargé — résolu en ajoutant `api: __DIR__.'/../routes/api.php'` dans `bootstrap/app.php`
- `Target class [subscribed] does not exist` (HTTP 500) : middleware `subscribed` inexistant retiré de `routes/api.php` — la vérification d'abonnement est dans `ApiAuthController@login`
- Redirection après inscription vers `/dashboard` (inexistant) → corrigé en `route('home')` dans `RegisteredUserController@store`